### PR TITLE
add devcontainer configuration for AZ-2007 GitHub Copilot development…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,67 @@
+{
+  "name": "AZ-2007 GitHub Copilot Development Environment",
+  "image": "mcr.microsoft.com/devcontainers/universal:2-linux",
+  
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "8.0",
+      "installUsingApt": false
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "18"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "latest"
+    }
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.vscode-dotnet-runtime",
+        "ms-python.python",
+        "ms-python.pylint",
+        "ms-python.flake8",
+        "ms-vscode.vscode-json",
+        "yzhang.markdown-all-in-one",
+        "DavidAnson.vscode-markdownlint",
+        "ms-vscode.powershell"
+      ],
+      "settings": {
+        "github.copilot.enable": {
+          "*": true,
+          "yaml": true,
+          "plaintext": true,
+          "markdown": true
+        },
+        "github.copilot.advanced": {
+          "debug.overrideEngine": "copilot",
+          "debug.testOverrideProxyUrl": "",
+          "debug.overrideProxyUrl": ""
+        },
+        "python.defaultInterpreterPath": "/usr/local/python/current/bin/python",
+        "python.formatting.provider": "black",
+        "python.linting.enabled": true,
+        "python.linting.pylintEnabled": true,
+        "dotnet.defaultSolution": "disable",
+        "omnisharp.enableEditorConfigSupport": true,
+        "omnisharp.enableRoslynAnalyzers": true
+      }
+    }
+  },
+
+  "forwardPorts": [3000, 5000, 5001, 8000, 8080],
+  
+  "postCreateCommand": "bash -c 'echo \"Development container ready for AZ-2007 GitHub Copilot training!\" && echo \"GitHub Copilot extensions should be available in VS Code.\"'",
+  
+  "remoteUser": "vscode",
+  
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind,consistency=cached",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
+}


### PR DESCRIPTION
This pull request introduces a new development environment configuration for GitHub Copilot training by adding a `.devcontainer/devcontainer.json` file. The configuration sets up a universal container image, installs multiple language runtimes and tools, and customizes the VS Code experience for enhanced productivity.

Development environment setup:

* Added `.devcontainer/devcontainer.json` to define a containerized development environment using the `mcr.microsoft.com/devcontainers/universal:2-linux` image.
* Configured features to install .NET 8.0, Python 3.11, Node.js 18, and the latest Git version for multi-language support.

VS Code customization:

* Pre-installed essential extensions for Copilot, Python, .NET, Markdown, PowerShell, and JSON, and set up recommended editor settings for linting and formatting.

Workspace and networking:

* Enabled port forwarding for common development ports (3000, 5000, 5001, 8000, 8080) and configured workspace mounting for seamless local development.
* Set up a post-creation command to notify users when the container is ready and Copilot extensions are available.… environment

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-