### PR TITLE
Backfill missing lab metadata (1 files)

### DIFF
--- a/Instructions/Labs/LAB_AK_01_analyze_document_code_github_copilot.md
+++ b/Instructions/Labs/LAB_AK_01_analyze_document_code_github_copilot.md
@@ -1,8 +1,18 @@
 ---
 lab:
-    title: 'Lab: Accelerate app development by using GitHub Copilot'
-    type: 'Answer Key'
-    module: 'Modules 2-5'
+  title: 'Lab: Accelerate app development by using GitHub Copilot'
+  type: Answer Key
+  module: Modules 2-5
+  description: You're a software developer working for a regional IT department. Most
+    of the applications that you work on support the local community. Recently, the
+    community library's servers were damaged in an accident, and it will take weeks
+    to get the authorization to replace them. Your department needs to develop a temporary
+    solution that will enable librarians to perform basic functions.
+  duration: 190 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - GitHub
 ---
 
 # Lab: Accelerate app development by using GitHub Copilot


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 1

- `Instructions/Labs/LAB_AK_01_analyze_document_code_github_copilot.md` (description,duration,level,islab,primarytopics)
