### PR TITLE
Backfill missing lab metadata (1 files)

### DIFF
--- a/Instructions/Labs/LAB_AK_01_analyze_document_code_github_copilot.md
+++ b/Instructions/Labs/LAB_AK_01_analyze_document_code_github_copilot.md
@@ -1,15 +1,12 @@
 ---
 lab:
   title: 'Lab: Accelerate app development by using GitHub Copilot'
-  type: Answer Key
-  module: Modules 2-5
   description: In this exercise, you used GitHub Copilot to evaluate the existing UnitTests project and extend the project to begin testing the data access classes in the Library.Infrastructure project. You added a reference to the Library.Infrastructure project in the UnitTests.csproj file and created unit tests for the JsonLoanRepository class. You used GitHub Copilot to help you write the unit tests for the GetLoan method in the JsonLoanRepository class. You ran the unit tests using Visual Studio Code's Test Explorer and verified that the tests passed.
   duration: 190 minutes
   level: 200
   islab: true
   primarytopics:
     - GitHub
-    - Visual Studio
     - Visual Studio Code
 ---
 

--- a/Instructions/Labs/LAB_AK_01_analyze_document_code_github_copilot.md
+++ b/Instructions/Labs/LAB_AK_01_analyze_document_code_github_copilot.md
@@ -1,8 +1,16 @@
 ---
 lab:
-    title: 'Lab: Accelerate app development by using GitHub Copilot'
-    type: 'Answer Key'
-    module: 'Modules 2-5'
+  title: 'Lab: Accelerate app development by using GitHub Copilot'
+  type: Answer Key
+  module: Modules 2-5
+  description: In this exercise, you used GitHub Copilot to evaluate the existing UnitTests project and extend the project to begin testing the data access classes in the Library.Infrastructure project. You added a reference to the Library.Infrastructure project in the UnitTests.csproj file and created unit tests for the JsonLoanRepository class. You used GitHub Copilot to help you write the unit tests for the GetLoan method in the JsonLoanRepository class. You ran the unit tests using Visual Studio Code's Test Explorer and verified that the tests passed.
+  duration: 190 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - GitHub
+    - Visual Studio
+    - Visual Studio Code
 ---
 
 # Lab: Accelerate app development by using GitHub Copilot


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 1

- `Instructions/Labs/LAB_AK_01_analyze_document_code_github_copilot.md` (description,duration,level,islab,primarytopics)
